### PR TITLE
Revising the integration approach for planetary motion

### DIFF
--- a/planetary_motion/planetary_motion.js
+++ b/planetary_motion/planetary_motion.js
@@ -32,23 +32,33 @@ function calcScale() {
     scale_display.innerHTML = `Scale: ${scale.toFixed(0)} pixels = ${(3 * getFarthestDistance()).toFixed(2)} length units`;
 }
 
-function update() {
+function update_acceleration() {
     for (let i = 0; i < params.length; i++) {
-        ax = 0;
-        ay = 0;
+        params[i].ax = 0;
+        params[i].ay = 0;
 
         for (let j = 0; j < params.length; j++) {
             if (i != j) {
-                ax += (- G * params[j].m * (params[i].x - params[j].x) / Math.pow(distance(params[i].x, params[i].y, params[j].x, params[j].y), 3));
-                ay += (- G * params[j].m * (params[i].y - params[j].y) / Math.pow(distance(params[i].x, params[i].y, params[j].x, params[j].y), 3));
+                params[i].ax += (- G * params[j].m * (params[i].x - params[j].x) / Math.pow(distance(params[i].x, params[i].y, params[j].x, params[j].y), 3));
+                params[i].ay += (- G * params[j].m * (params[i].y - params[j].y) / Math.pow(distance(params[i].x, params[i].y, params[j].x, params[j].y), 3));
             }
         }
+    }
+}
 
-        params[i].vx += (ax * prec);
-        params[i].vy += (ay * prec);
+/*Applying velocity Verlet integration steps.*/
+function update() {
+    for (let i = 0; i < params.length; i++) {
+        params[i].vx += 0.5*(params[i].ax * prec);
+        params[i].vy += 0.5*(params[i].ay * prec);
 
         params[i].x += (params[i].vx * prec);
         params[i].y += (params[i].vy * prec);
+    }
+    update_acceleration();
+    for (let i = 0; i < params.length; i++) {
+        params[i].vx += 0.5*(params[i].ax * prec);
+        params[i].vy += 0.5*(params[i].ay * prec);
     }
 
     while(trails.length > trails_limit * num_entities) {
@@ -95,8 +105,11 @@ function startSimulation() {
             y: bodies[i].y,
             vx: bodies[i].vx,
             vy: bodies[i].vy,
+            ax: bodies[i].ax,
+            ay: bodies[i].ay,
         });
     }
+    update_acceleration();
 }
 
 function pause() {
@@ -163,6 +176,8 @@ function phenomena(number) {
                 y: 0,
                 vx: 0,
                 vy: 0,
+                ax: 0,
+                ay: 0,
             },
             {
                 m: 100,
@@ -170,6 +185,8 @@ function phenomena(number) {
                 y: 0,
                 vx: 0,
                 vy: 10,
+                ax: 0,
+                ay: 0,
             }
         )
         substituteParams();
@@ -186,6 +203,8 @@ function phenomena(number) {
                 y: 0,
                 vx: 0,
                 vy: 0,
+                ax: 0,
+                ay: 0,
             },
             {
                 m: 1,
@@ -193,6 +212,8 @@ function phenomena(number) {
                 y: -5,
                 vx: -3,
                 vy: 3,
+                ax: 0,
+                ay: 0,
             },
             {
                 m: 1,
@@ -200,6 +221,8 @@ function phenomena(number) {
                 y: 5,
                 vx: 4.5,
                 vy: 0,
+                ax: 0,
+                ay: 0,
             }
         )
         substituteParams();
@@ -216,6 +239,8 @@ function phenomena(number) {
                 y: 0,
                 vx: 0,
                 vy: -5,
+                ax: 0,
+                ay: 0,
             },
             {
                 m: 500,
@@ -223,6 +248,8 @@ function phenomena(number) {
                 y: 0,
                 vx: 0,
                 vy: 5,
+                ax: 0,
+                ay: 0,
             }
         )
         substituteParams();
@@ -239,6 +266,8 @@ function phenomena(number) {
                 y: 0,
                 vx: 0,
                 vy: 0,
+                ax: 0,
+                ay: 0,
             },
             {
                 m: 1,
@@ -246,6 +275,8 @@ function phenomena(number) {
                 y: 0,
                 vx: 0,
                 vy: 5,
+                ax: 0,
+                ay: 0,
             },
             {
                 m: 1,
@@ -253,6 +284,8 @@ function phenomena(number) {
                 y: 0,
                 vx: 0,
                 vy: 3,
+                ax: 0,
+                ay: 0,
             }
         )
         substituteParams();
@@ -269,6 +302,8 @@ function phenomena(number) {
                 y: 0,
                 vx: 0,
                 vy: 0,
+                ax: 0,
+                ay: 0,
             },
             {
                 m: 10,
@@ -276,6 +311,8 @@ function phenomena(number) {
                 y: 0,
                 vx: 0,
                 vy: 10,
+                ax: 0,
+                ay: 0,
             },
             {
                 m: 10,
@@ -283,6 +320,8 @@ function phenomena(number) {
                 y: 0,
                 vx: 0,
                 vy: -10,
+                ax: 0,
+                ay: 0,
             }
         )
         substituteParams();

--- a/planetary_motion/simulation.html
+++ b/planetary_motion/simulation.html
@@ -128,9 +128,7 @@
 
   <h3 class="center-align">Planetary Phenomena</h3>
   <ol>
-    <li><b>Unstable orbit:</b> Here, the planet's total energy is actually positive. Hence it is not actually bound to
-      the star and instead revolves around an unstable orbit before getting ejected. Moreover, the planet is only
-      10 times lighter than the star, causing the star to wobble.
+    <li><b>Precessing orbit:</b> The use of the velocity Verlet integration preserves the total energy of the planetary system. The drifting of the system given the initial conditions is expected. Furthermore, the wobble of the star is also expected due to the planet being only 10 times less massive than its star. While stable in the sense of preserving the total energy (for the default step size) and the shape and size of the orbits, the simulated orbits deviate from their theoretical trajectories in that orbital precession is evident as an artefact of the integration approach. 
       <br> <br>
       <center>
         <button class="btn purple darken-4" onclick="phenomena(1)">Simulate</button>
@@ -164,11 +162,7 @@
     </li>
     <br>
     <li>
-      <b>Planetary dance:</b> The two planets initially revolve symmetrically around the star. However, they come quite
-      close
-      four times and exchange energy during each interaction. The planet that continually loses energy occupies
-      a lower orbit and eventually gets ejected whereas the planet that continually gains energy settles in an highly
-      elliptical orbit.
+      <b>Planetary dance:</b> The two planets revolve symmetrically around the star, staying in stable (but precessing) orbits.
       <br> <br>
       <center>
         <button class="btn purple darken-4" onclick="phenomena(5)">Simulate</button>


### PR DESCRIPTION
Hello, 

I made some changes to planetary_motion.js to have the phase space updates use a velocity Verlet approach, which while only 2nd order, has favourable stability properties for molecular dynamics. As a result of making these two changes, two of the example simulations that were unstable are now stable (although the orbits precess for the default step size value). I also updated the corresponding descriptions. 

I've made other changes, like showing the theoretical orbit in the case of 2-body problems, which I may push separately at a later time.

Kind regards,
Brian Dandurand